### PR TITLE
Add config file for API data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,16 @@ The project involves the following components:
    pip install -r requirements.txt
    ```
 
-3. Set up your Nature Remo API access token:
+3. Set up your Nature Remo API access token and TP-Link Smart Plug IP address:
    - Obtain your access token from the Nature Remo developer portal.
-   - Set the access token in the `monitoring.py` file.
+   - Create a `config.ini` file in the root directory of the project with the following content:
+     ```
+     [NatureRemo]
+     token = YOUR_ACCESS_TOKEN
+
+     [TPLink]
+     ip_address = YOUR_SMART_PLUG_IP_ADDRESS
+     ```
 
 4. Set up your TP-Link Smart Plug:
    - Ensure your TP-Link Smart Plug is connected to your LAN.

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,5 @@
+[NatureRemo]
+token = YOUR_ACCESS_TOKEN
+
+[TPLink]
+ip_address = YOUR_SMART_PLUG_IP_ADDRESS

--- a/main.py
+++ b/main.py
@@ -1,10 +1,13 @@
 import time
+import configparser
 from monitoring import get_nature_remo_data, display_data
 from control import control_plugs_based_on_data
 
 def main():
-    token = 'YOUR_ACCESS_TOKEN'
-    ip_address = 'YOUR_SMART_PLUG_IP_ADDRESS'
+    config = configparser.ConfigParser()
+    config.read('config.ini')
+    token = config['NatureRemo']['token']
+    ip_address = config['TPLink']['ip_address']
     
     while True:
         data = get_nature_remo_data(token)


### PR DESCRIPTION
Store API data in a `config.ini` file instead of hardcoding.

* **config.ini**
  - Add a new file to store the access token and IP address.
  - Add a section `[NatureRemo]` with a key `token` for the access token.
  - Add a section `[TPLink]` with a key `ip_address` for the smart plug IP address.

* **main.py**
  - Import the `configparser` module to read the `config.ini` file.
  - Read the access token and IP address from the `config.ini` file.
  - Remove the hardcoded access token and IP address.

* **README.md**
  - Update the setup instructions to include creating and configuring the `config.ini` file.
  - Remove the instruction to set the access token in the `monitoring.py` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NEXTAltair/NatureRemoMatterControl?shareId=82d99827-f154-4491-9908-0d17b7824cb4).